### PR TITLE
Increment sequence for universe in E1.31 packets

### DIFF
--- a/lumos/packet.py
+++ b/lumos/packet.py
@@ -102,9 +102,9 @@ class RootLayer(LayerBase):
 
 
 class E131Packet(object):
-    def __init__(self, cid=None, name=None, universe=None, data=[]):
+    def __init__(self, cid=None, name=None, universe=None, data=[], sequence=0):
         self.dmp_packet = DMPLayer(data=data).packet_data()
         self.framing_packet = FramingLayer(name=name, universe=universe,
-                dmp_packet=self.dmp_packet).packet_data()
+                dmp_packet=self.dmp_packet, sequence=sequence).packet_data()
         self.packet_data = RootLayer(cid=cid, framing_packet=self.framing_packet).packet_data()
 

--- a/lumos/source.py
+++ b/lumos/source.py
@@ -25,6 +25,7 @@ class DMXSource(object):
     def __init__(self, universe=1, network_segment=1, bind_ip=None):
         self.universe = universe
         self.ip = ip_from_universe(universe)
+        self.sequence = 0
         # open UDP socket
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         if bind_ip:
@@ -35,5 +36,9 @@ class DMXSource(object):
         self.sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
 
     def send_data(self, data):
-        packet = E131Packet(universe=self.universe, data=data)
+        packet = E131Packet(universe=self.universe, data=data, sequence=self.sequence)
+        if self.sequence == 255:
+            self.sequence = 0
+        else:
+            self.sequence += 1
         self.sock.sendto(packet.packet_data, (self.ip, 5568))


### PR DESCRIPTION
Incrementing sequence number is required by E1.31 spec and is expected by some receivers, such as SACNView. This update tracks sequence number in the DMXSource instance, meaning this logic assumes there's a single DMXSource instance transmitting packets for a particular universe at a time. If this is not the case, the sequence will not have expected values and receivers may ignore packets.

May add support for multiple DMXSources with same universes sharing sequence numbers in the future, but not needed for my use case for now.
